### PR TITLE
Improved code formatting and TOTP: TimeStepWindow

### DIFF
--- a/Source/radRTL.BitUtils.pas
+++ b/Source/radRTL.BitUtils.pas
@@ -6,15 +6,13 @@ unit radRTL.BitUtils;
 interface
 
 // given decimal 49 ('00110001') if you want the last 2 bits '01' then ExtractLastBits(49, 2) = 1
-function ExtractLastBits(const pValue:Integer; const pBitsToExtract:Integer):Integer;
-
+function ExtractLastBits(const pValue: Integer; const pBitsToExtract: Integer): Integer;
 
 implementation
 
-
-function ExtractLastBits(const pValue:Integer; const pBitsToExtract:Integer):Integer;
+function ExtractLastBits(const pValue: Integer; const pBitsToExtract: Integer): Integer;
 var
-  vMask:Int64;  //Int64 to overcome "1 shl 31"
+  vMask: Int64;  //Int64 to overcome "1 shl 31"
 begin
   if pBitsToExtract > 0 then
   begin
@@ -22,10 +20,7 @@ begin
     Result := pValue and (vMask and $FFFFFFFF);
   end
   else
-  begin
     Result := 0;
-  end;
 end;
-
 
 end.

--- a/Source/radRTL.ByteArrayUtils.pas
+++ b/Source/radRTL.ByteArrayUtils.pas
@@ -8,69 +8,53 @@ interface
 uses
   System.SysUtils;
 
+function ConvertToByteArray(const pValue: Integer): TBytes; overload;
+function ConvertToByteArray(const pValue: Int64): TBytes; overload;
 
-function ConvertToByteArray(const pValue:Integer):TBytes; overload;
-function ConvertToByteArray(const pValue:Int64):TBytes; overload;
-
-function ByteArraysMatch(const pArray1, pArray2:TBytes):Boolean;
-function ReverseByteArray(const pSource:TBytes):TBytes;
-
+function ByteArraysMatch(const pArray1, pArray2: TBytes): Boolean;
+function ReverseByteArray(const pSource: TBytes): TBytes;
 
 implementation
 
-
-function ConvertToByteArray(const pValue:Integer):TBytes;
+function ConvertToByteArray(const pValue: Integer): TBytes;
 begin
   SetLength(Result, SizeOf(Integer));
   PInteger(@Result[0])^ := pValue;
 end;
 
-
-function ConvertToByteArray(const pValue:Int64):TBytes;
+function ConvertToByteArray(const pValue: Int64): TBytes;
 begin
   SetLength(Result, SizeOf(Int64));
   PInt64(@Result[0])^ := pValue;
 end;
 
-
-function ReverseByteArray(const pSource:TBytes):TBytes;
+function ReverseByteArray(const pSource: TBytes): TBytes;
 var
-  vArrayLength:Integer;
-  i:Integer;
+  vArrayLength: Integer;
+  i: Integer;
 begin
   vArrayLength := Length(pSource);
   SetLength(Result, vArrayLength);
 
   if vArrayLength > 0 then
-  begin
     for i := Low(pSource) to High(pSource) do
-    begin
       Result[High(pSource) - i] := pSource[i];
-    end;
-  end;
 end;
 
-
-function ByteArraysMatch(const pArray1, pArray2:TBytes):Boolean;
+function ByteArraysMatch(const pArray1, pArray2: TBytes): Boolean;
 var
-  vArrayLength:Integer;
+  vArrayLength: Integer;
 begin
   vArrayLength := Length(pArray1);
   if vArrayLength = 0 then
-  begin
-    Result := Length(pArray2) = 0;
-  end
+    Result := Length(pArray2) = 0
   else
   begin
     Result := vArrayLength = Length(pArray2);
 
     if Result then
-    begin
       Result := CompareMem(@pArray1[0], @pArray2[0], vArrayLength);
-    end;
   end;
-
 end;
-
 
 end.

--- a/Source/radRTL.TOTP.pas
+++ b/Source/radRTL.TOTP.pas
@@ -14,10 +14,11 @@ type
   private const
     TimeStepWindow = 30; // 30 is recommended value. "The prover and verifier MUST use the same time-step"
   protected
-    class function GetCurrentUnixTimestamp: Int64;
+    class function GetCurrentUnixTimestamp(ATimeStepWindow: Integer): Int64;
   public
     /// <summary> TOTP: Time-Based One-Time Password Algorithm (most commonly used by Google Authenticaor)</summary>
-    class function GeneratePassword(const pBase32EncodedSecretKey: string; const pOutputLength: TOTPLength = TOTPLength.SixDigits): string; overload;
+    class function GeneratePassword(const pBase32EncodedSecretKey: string; const pOutputLength: TOTPLength = TOTPLength.SixDigits;
+      ATimeStepWindow: Integer = TimeStepWindow): string; overload;
   end;
 
 implementation
@@ -25,15 +26,16 @@ implementation
 uses
   System.DateUtils;
 
-class function TTOTP.GetCurrentUnixTimestamp: Int64;
+class function TTOTP.GetCurrentUnixTimestamp(ATimeStepWindow: Integer): Int64;
 begin
-  Result := DateTimeToUnix(Now, {AInputIsUTC=}False) div TTOTP.TimeStepWindow;
+  Result := DateTimeToUnix(Now, {AInputIsUTC=}False) div ATimeStepWindow;
 end;
 
 // https://datatracker.ietf.org/doc/html/rfc6238
-class function TTOTP.GeneratePassword(const pBase32EncodedSecretKey: string; const pOutputLength: TOTPLength = TOTPLength.SixDigits): string;
+class function TTOTP.GeneratePassword(const pBase32EncodedSecretKey: string; const pOutputLength: TOTPLength = TOTPLength.SixDigits;
+  ATimeStepWindow: Integer = TimeStepWindow): string;
 begin
-  Result := THOTP.GeneratePassword(pBase32EncodedSecretKey, GetCurrentUnixTimestamp, pOutputLength);
+  Result := THOTP.GeneratePassword(pBase32EncodedSecretKey, GetCurrentUnixTimestamp(ATimeStepWindow), pOutputLength);
 end;
 
 end.

--- a/Source/radRTL.TOTP.pas
+++ b/Source/radRTL.TOTP.pas
@@ -10,38 +10,30 @@ uses
   radRTL.HOTP;
 
 type
-
-
   TTOTP = class(THOTP)
   private const
     TimeStepWindow = 30; // 30 is recommended value. "The prover and verifier MUST use the same time-step"
   protected
-    class function GetCurrentUnixTimestamp():Int64;
+    class function GetCurrentUnixTimestamp: Int64;
   public
     /// <summary> TOTP: Time-Based One-Time Password Algorithm (most commonly used by Google Authenticaor)</summary>
-    class function GeneratePassword(const pBase32EncodedSecretKey:string; const pOutputLength:TOTPLength = TOTPLength.SixDigits):string; overload;
+    class function GeneratePassword(const pBase32EncodedSecretKey: string; const pOutputLength: TOTPLength = TOTPLength.SixDigits): string; overload;
   end;
-
-
 
 implementation
 
 uses
   System.DateUtils;
 
-
-class function TTOTP.GetCurrentUnixTimestamp():Int64;
+class function TTOTP.GetCurrentUnixTimestamp: Int64;
 begin
   Result := DateTimeToUnix(Now, {AInputIsUTC=}False) div TTOTP.TimeStepWindow;
 end;
 
-
 // https://datatracker.ietf.org/doc/html/rfc6238
-class function TTOTP.GeneratePassword(const pBase32EncodedSecretKey:string; const pOutputLength:TOTPLength = TOTPLength.SixDigits):string;
+class function TTOTP.GeneratePassword(const pBase32EncodedSecretKey: string; const pOutputLength: TOTPLength = TOTPLength.SixDigits): string;
 begin
   Result := THOTP.GeneratePassword(pBase32EncodedSecretKey, GetCurrentUnixTimestamp, pOutputLength);
 end;
-
-
 
 end.


### PR DESCRIPTION
Added a lot of spaces, fixed some capital letters and removed some unnecessary begin/end blocks. All according to the latest Delphi styling guides.

TOTP: TimeStepWindow can be changed from the default 30 seconds.